### PR TITLE
Update balanceOf signature

### DIFF
--- a/src/interfaces/IERC20.sol
+++ b/src/interfaces/IERC20.sol
@@ -6,7 +6,7 @@ interface IERC20 {
 
     function approve(address, uint256) external;
 
-    function balanceOf(address) external returns (uint256);
+    function balanceOf(address) external view returns (uint256);
 
     function transfer(address, uint256) external;
 


### PR DESCRIPTION
balanceOf signature should be restricted to view so it uses a static call rather than a regular call to the contract (avoids potential attacks by malicious contracts who's balanceOf implementation is capable of changing state).