### PR TITLE
Fix typo in struct field name

### DIFF
--- a/src/lib/Tick.sol
+++ b/src/lib/Tick.sol
@@ -9,7 +9,7 @@ library Tick {
         bool initialized;
         // total liquidity at tick
         uint128 liquidityGross;
-        // amount of liqudiity added or subtracted when tick is crossed
+        // amount of liquidity added or subtracted when tick is crossed
         int128 liquidityNet;
         // fee growth on the other side of this tick (relative to the current tick)
         uint256 feeGrowthOutside0X128;

--- a/test/UniswapV3Pool.Swaps.t.sol
+++ b/test/UniswapV3Pool.Swaps.t.sol
@@ -48,7 +48,7 @@ contract UniswapV3PoolSwapsTest is Test, UniswapV3PoolUtils {
                     ),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
 
@@ -135,7 +135,7 @@ contract UniswapV3PoolSwapsTest is Test, UniswapV3PoolUtils {
                     liquidity: liquidityRanges(range, range),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
 
@@ -233,7 +233,7 @@ contract UniswapV3PoolSwapsTest is Test, UniswapV3PoolUtils {
                     ),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
 
@@ -372,7 +372,7 @@ contract UniswapV3PoolSwapsTest is Test, UniswapV3PoolUtils {
                     ),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
 
@@ -505,7 +505,7 @@ contract UniswapV3PoolSwapsTest is Test, UniswapV3PoolUtils {
                     ),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
 
@@ -586,7 +586,7 @@ contract UniswapV3PoolSwapsTest is Test, UniswapV3PoolUtils {
                     ),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
 
@@ -673,7 +673,7 @@ contract UniswapV3PoolSwapsTest is Test, UniswapV3PoolUtils {
                     liquidity: liquidityRanges(range, range),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
 
@@ -771,7 +771,7 @@ contract UniswapV3PoolSwapsTest is Test, UniswapV3PoolUtils {
                     ),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
 
@@ -910,7 +910,7 @@ contract UniswapV3PoolSwapsTest is Test, UniswapV3PoolUtils {
                     ),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
 
@@ -1043,7 +1043,7 @@ contract UniswapV3PoolSwapsTest is Test, UniswapV3PoolUtils {
                     ),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
 
@@ -1114,7 +1114,7 @@ contract UniswapV3PoolSwapsTest is Test, UniswapV3PoolUtils {
             liquidity: liquidity,
             transferInMintCallback: true,
             transferInSwapCallback: true,
-            mintLiqudity: true
+            mintLiquidity: true
         });
         setupPool(params);
 
@@ -1135,7 +1135,7 @@ contract UniswapV3PoolSwapsTest is Test, UniswapV3PoolUtils {
             liquidity: liquidity,
             transferInMintCallback: true,
             transferInSwapCallback: true,
-            mintLiqudity: true
+            mintLiquidity: true
         });
         setupPool(params);
 
@@ -1161,7 +1161,7 @@ contract UniswapV3PoolSwapsTest is Test, UniswapV3PoolUtils {
                     ),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
 
@@ -1254,7 +1254,7 @@ contract UniswapV3PoolSwapsTest is Test, UniswapV3PoolUtils {
             liquidity: liquidity,
             transferInMintCallback: true,
             transferInSwapCallback: false,
-            mintLiqudity: true
+            mintLiquidity: true
         });
         setupPool(params);
 
@@ -1272,7 +1272,7 @@ contract UniswapV3PoolSwapsTest is Test, UniswapV3PoolUtils {
                 ),
                 transferInMintCallback: true,
                 transferInSwapCallback: true,
-                mintLiqudity: true
+                mintLiquidity: true
             })
         );
 
@@ -1346,7 +1346,7 @@ contract UniswapV3PoolSwapsTest is Test, UniswapV3PoolUtils {
                 ),
                 transferInMintCallback: true,
                 transferInSwapCallback: true,
-                mintLiqudity: true
+                mintLiquidity: true
             })
         );
 
@@ -1516,7 +1516,7 @@ contract UniswapV3PoolSwapsTest is Test, UniswapV3PoolUtils {
             params.currentPrice
         );
 
-        if (params.mintLiqudity) {
+        if (params.mintLiquidity) {
             weth.approve(address(this), params.balances[0]);
             usdc.approve(address(this), params.balances[1]);
 

--- a/test/UniswapV3Pool.Utils.t.sol
+++ b/test/UniswapV3Pool.Utils.t.sol
@@ -18,7 +18,7 @@ abstract contract UniswapV3PoolUtils is Test, TestUtils {
         LiquidityRange[] liquidity;
         bool transferInMintCallback;
         bool transferInSwapCallback;
-        bool mintLiqudity;
+        bool mintLiquidity;
     }
 
     function liquidityRange(

--- a/test/UniswapV3Pool.t.sol
+++ b/test/UniswapV3Pool.t.sol
@@ -89,7 +89,7 @@ contract UniswapV3PoolTest is Test, UniswapV3PoolUtils {
                     ),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
 
@@ -154,7 +154,7 @@ contract UniswapV3PoolTest is Test, UniswapV3PoolUtils {
                     ),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
 
@@ -219,7 +219,7 @@ contract UniswapV3PoolTest is Test, UniswapV3PoolUtils {
                     ),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
 
@@ -283,7 +283,7 @@ contract UniswapV3PoolTest is Test, UniswapV3PoolUtils {
                 ),
                 transferInMintCallback: true,
                 transferInSwapCallback: true,
-                mintLiqudity: true
+                mintLiquidity: true
             })
         );
 
@@ -357,7 +357,7 @@ contract UniswapV3PoolTest is Test, UniswapV3PoolUtils {
                 ),
                 transferInMintCallback: true,
                 transferInSwapCallback: true,
-                mintLiqudity: true
+                mintLiquidity: true
             })
         );
 
@@ -436,7 +436,7 @@ contract UniswapV3PoolTest is Test, UniswapV3PoolUtils {
                     ),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
 
@@ -515,7 +515,7 @@ contract UniswapV3PoolTest is Test, UniswapV3PoolUtils {
                     ),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
         LiquidityRange memory liq = liquidity[0];
@@ -610,7 +610,7 @@ contract UniswapV3PoolTest is Test, UniswapV3PoolUtils {
                     ),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
         LiquidityRange memory liq = liquidity[0];
@@ -684,7 +684,7 @@ contract UniswapV3PoolTest is Test, UniswapV3PoolUtils {
                 ),
                 transferInMintCallback: true,
                 transferInSwapCallback: true,
-                mintLiqudity: true
+                mintLiquidity: true
             })
         );
         LiquidityRange memory liq = liquidity[0];
@@ -744,7 +744,7 @@ contract UniswapV3PoolTest is Test, UniswapV3PoolUtils {
                     ),
                     transferInMintCallback: true,
                     transferInSwapCallback: true,
-                    mintLiqudity: true
+                    mintLiquidity: true
                 })
             );
         LiquidityRange memory liq = liquidity[0];
@@ -850,7 +850,7 @@ contract UniswapV3PoolTest is Test, UniswapV3PoolUtils {
                 ),
                 transferInMintCallback: false,
                 transferInSwapCallback: true,
-                mintLiqudity: false
+                mintLiquidity: false
             })
         );
 
@@ -874,7 +874,7 @@ contract UniswapV3PoolTest is Test, UniswapV3PoolUtils {
                 ),
                 transferInMintCallback: true,
                 transferInSwapCallback: true,
-                mintLiqudity: true
+                mintLiquidity: true
             })
         );
 
@@ -978,7 +978,7 @@ contract UniswapV3PoolTest is Test, UniswapV3PoolUtils {
             params.currentPrice
         );
 
-        if (params.mintLiqudity) {
+        if (params.mintLiquidity) {
             weth.approve(address(this), params.balances[0]);
             usdc.approve(address(this), params.balances[1]);
 


### PR DESCRIPTION
Change all instances:
`PoolParams:mintLiqudity` to `PoolParams:mintLiquidity`